### PR TITLE
Performance improvements

### DIFF
--- a/pamrel/templates/paste.html
+++ b/pamrel/templates/paste.html
@@ -1,5 +1,6 @@
 {% extends 'base.html' %}
-{% load staticfiles %}
+{% load cache staticfiles %}
+
 {% block css %}
     <link rel="stylesheet" type="text/css" href="{% static 'css/font-awesome.css' %}">
     {% if theme_path %}
@@ -17,11 +18,13 @@
 {% endblock %}
 
 {% block content %}
-    <div class="view-paste">
-        {% if object.syntax %}
-            {{ content|safe }}
-        {% else %}
-            <pre>{{ content }}</pre>
-        {% endif %}
-    </div>
+    {% cache 21600 paste paste.id %}
+        <div class="view-paste">
+            {% if object.syntax %}
+                {{ content|safe }}
+            {% else %}
+                <pre>{{ content }}</pre>
+            {% endif %}
+        </div>
+    {% endcache %}
 {% endblock %}

--- a/pamrel/views.py
+++ b/pamrel/views.py
@@ -89,7 +89,7 @@ class PasteView(DetailView):
 
         if isinstance(self.object, Paste):
             object.viewed += 1
-            object.save()
+            object.save(update_fields=["viewed"])
             return True
 
         return False

--- a/pamrel/views.py
+++ b/pamrel/views.py
@@ -136,7 +136,8 @@ class PasteView(DetailView):
         context["theme_path"] = "{0}.css".format(self.object.theme)
 
         if self.object.language != "PlainText":
-            context["content"] = self.highlight_paste()
+            # pass in a method - it will only be rendered if we don't have a cached copy
+            context["content"] = self.highlight_paste
         else:
             context["highlighted"] = True
 


### PR DESCRIPTION
A couple of changes that should make pamrel a bit snappier:

* Cache pygments output - the paste isn't going to change and pygments doesn't get updated often enough to warrant regenerating the highlighted output each time
* Don't save the entire object back to the database when updating the `viewed` field.